### PR TITLE
Void miner stable work fix

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/miner/MetaTileEntityVoidMiner.java
+++ b/src/main/java/gregicadditions/machines/multi/miner/MetaTileEntityVoidMiner.java
@@ -174,13 +174,13 @@ public class MetaTileEntityVoidMiner extends GAMultiblockWithDisplayBase { //tod
 
                 if (usingPyrotheum && canDrainPyrotheum != null && canDrainPyrotheum.amount == (int) currentDrillingFluid) {
                     importFluidHandler.drain(pyrotheumFluid, true);
-                    temperature += currentDrillingFluid / 100;
+                    temperature += (int)(currentDrillingFluid / 100.0);
                     currentDrillingFluid = currentDrillingFluid * 1.02;
                     hasConsume = true;
                 } else if (temperature > 0 && canDrainCryotheum != null && canDrainCryotheum.amount == (int) currentDrillingFluid) {
                     importFluidHandler.drain(cryotheumFluid, true);
-                    temperature -= currentDrillingFluid / 100;
-                    currentDrillingFluid = currentDrillingFluid * 0.98;
+                    currentDrillingFluid = currentDrillingFluid / 1.02;
+                    temperature -= (int)(currentDrillingFluid / 100.0);
                 }
                 if (temperature < 0) {
                     temperature = 0;


### PR DESCRIPTION
Small fix for void miner.
problem:
The void miner was constantly cooling down due to asymmetric heating and cooling with the same amount of liquids. Without explicit type casting, an inaccuracy occurred: the cooling was 1 degree more than the heating. And 1 / 1.02 not equal 1 * 0.98.