### PR TITLE
Allow Large Engraver to Use Fluid Hatches

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeLaserEngraver.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeLaserEngraver.java
@@ -39,8 +39,11 @@ public class TileEntityLargeLaserEngraver extends LargeSimpleRecipeMapMultiblock
         return new TileEntityLargeLaserEngraver(metaTileEntityId);
     }
 
-    private static final MultiblockAbility<?>[] ALLOWED_ABILITIES = {MultiblockAbility.IMPORT_ITEMS,
-            MultiblockAbility.EXPORT_ITEMS, MultiblockAbility.INPUT_ENERGY, GregicAdditionsCapabilities.MAINTENANCE_HATCH};
+    private static final MultiblockAbility<?>[] ALLOWED_ABILITIES = {
+            MultiblockAbility.IMPORT_ITEMS, MultiblockAbility.EXPORT_ITEMS,
+            MultiblockAbility.INPUT_ENERGY, MultiblockAbility.IMPORT_FLUIDS,
+            MultiblockAbility.EXPORT_FLUIDS, GregicAdditionsCapabilities.MAINTENANCE_HATCH
+    };
 
 
     @Override


### PR DESCRIPTION
Fixes the Large Laser Engraver not being able to use fluid hatches. This previously would have prevented the use of key progression recipes, such as making Fullerenes.