### PR TITLE
Fix The CT Constructor for Hot Coolant Turbine Recipes

### DIFF
--- a/src/main/java/gregicadditions/recipes/impl/nuclear/HotCoolantRecipe.java
+++ b/src/main/java/gregicadditions/recipes/impl/nuclear/HotCoolantRecipe.java
@@ -31,8 +31,8 @@ public class HotCoolantRecipe {
     @ZenMethod("create")
     @Method(modid = GTValues.MODID_CT)
     @SuppressWarnings("unused")
-    public static FuelRecipe craftTweakerCreate(ILiquidStack liquidStack, int duration, long minVoltage) {
-        return new FuelRecipe(CraftTweakerMC.getLiquidStack(liquidStack), duration, minVoltage);
+    public static HotCoolantRecipe craftTweakerCreate(ILiquidStack input, int duration, long minVoltage,ILiquidStack output) {
+        return new HotCoolantRecipe(CraftTweakerMC.getLiquidStack(input), duration, minVoltage,CraftTweakerMC.getLiquidStack(output));
     }
 
     public FluidStack getRecipeFluid() {

--- a/src/main/java/gregicadditions/recipes/impl/nuclear/HotCoolantRecipe.java
+++ b/src/main/java/gregicadditions/recipes/impl/nuclear/HotCoolantRecipe.java
@@ -31,8 +31,8 @@ public class HotCoolantRecipe {
     @ZenMethod("create")
     @Method(modid = GTValues.MODID_CT)
     @SuppressWarnings("unused")
-    public static HotCoolantRecipe craftTweakerCreate(ILiquidStack input, int duration, long minVoltage,ILiquidStack output) {
-        return new HotCoolantRecipe(CraftTweakerMC.getLiquidStack(input), duration, minVoltage,CraftTweakerMC.getLiquidStack(output));
+    public static HotCoolantRecipe craftTweakerCreate(ILiquidStack input, int duration, long minVoltage, ILiquidStack output) {
+        return new HotCoolantRecipe(CraftTweakerMC.getLiquidStack(input), duration, minVoltage, CraftTweakerMC.getLiquidStack(output));
     }
 
     public FluidStack getRecipeFluid() {


### PR DESCRIPTION
How:
Change the method to reflect the constructor of the hot coolant turbine instead of the standard FuelRecipe constructor.

Outcome: 
Recipes can be added to the hot coolant turbine via CT.

Possible compatibility issue:
None
