### PR TITLE
Fix Resorcinol+Hydroquinone recipe conflict with Phenol in LCR

### DIFF
--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -934,6 +934,15 @@ public class RecipeOverride {
                 .output(ingot, WroughtIron)
                 .output(dust, Rutile, 3)
                 .buildAndRegister();
+
+        // Phenol in LCR
+        removeRecipesByInputs(CHEMICAL_RECIPES, Benzene.getFluid(1000), Oxygen.getFluid(1000));
+        CHEMICAL_RECIPES.recipeBuilder().duration(400).EUt(2000)
+                .notConsumable(new IntCircuitIngredient(0))
+                .fluidInputs(Benzene.getFluid(1000))
+                .fluidInputs(Oxygen.getFluid(1000))
+                .fluidOutputs(Phenol.getFluid(1000))
+                .buildAndRegister();
     }
 
     private static void vanillaOverride() {

--- a/src/main/java/gregicadditions/recipes/chain/PEEKChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/PEEKChain.java
@@ -1,7 +1,5 @@
 package gregicadditions.recipes.chain;
 
-import gregtech.api.recipes.ingredients.IntCircuitIngredient;
-
 import static gregicadditions.GAMaterials.*;
 import static gregicadditions.recipes.GARecipeMaps.LARGE_CHEMICAL_RECIPES;
 import static gregtech.api.recipes.RecipeMaps.*;
@@ -150,7 +148,6 @@ public class PEEKChain {
 
         // C3H6 + C6H6 + 3O -> C3H6O + C6H6O2
         LARGE_CHEMICAL_RECIPES.recipeBuilder()
-                .notConsumable(new IntCircuitIngredient(25))
                 .fluidInputs(Propene.getFluid(1000))
                 .fluidInputs(Benzene.getFluid(1000))
                 .fluidInputs(Oxygen.getFluid(3000))

--- a/src/main/java/gregicadditions/recipes/chain/PEEKChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/PEEKChain.java
@@ -1,5 +1,7 @@
 package gregicadditions.recipes.chain;
 
+import gregtech.api.recipes.ingredients.IntCircuitIngredient;
+
 import static gregicadditions.GAMaterials.*;
 import static gregicadditions.recipes.GARecipeMaps.LARGE_CHEMICAL_RECIPES;
 import static gregtech.api.recipes.RecipeMaps.*;
@@ -148,6 +150,7 @@ public class PEEKChain {
 
         // C3H6 + C6H6 + 3O -> C3H6O + C6H6O2
         LARGE_CHEMICAL_RECIPES.recipeBuilder()
+                .notConsumable(new IntCircuitIngredient(25))
                 .fluidInputs(Propene.getFluid(1000))
                 .fluidInputs(Benzene.getFluid(1000))
                 .fluidInputs(Oxygen.getFluid(3000))


### PR DESCRIPTION
GSE 6.4 on Gregicality-1.12.2-0.23.3


I think this image explains it succinctly. Resorcinol and Hydroquinone are only craftable by LCR, for which there exists the phenol recipe which overrides with benzene and oxygen inputs. I added a configured circuit to the recipe. Resorcinol is used for the aerographene and PEEK crafting chains.


First pull request to a public repo I hope I did it right~ I tried compiling it to test it but I got the below error on the jar output when running it in forge and I don't know enough about compiling mods to know what the issue is... I would appreciate help with that. I imported in intellij, ran the "jar" target in gradle and used the jar from /build/libs.

```
java.lang.NoSuchMethodError: net.minecraft.util.ResourceLocation.getNamespace()Ljava/lang/String;
	at gregicadditions.blocks.AbstractBlockModelFactory.resourceExists(AbstractBlockModelFactory.java:46)
	at gregtech.api.model.ResourcePackHook.func_110589_b(ResourcePackHook.java:76)
	at net.minecraft.client.resources.FallbackResourceManager.func_135056_b(FallbackResourceManager.java:95)
	at net.minecraft.client.resources.SimpleReloadableResourceManager.func_135056_b(SimpleReloadableResourceManager.java:79)
	at net.minecraft.client.resources.Locale.func_135022_a(Locale.java:38)
	at net.minecraft.client.resources.LanguageManager.func_110549_a(SourceFile:67)
	at net.minecraft.client.resources.SimpleReloadableResourceManager.func_110544_b(SimpleReloadableResourceManager.java:132)
	at net.minecraft.client.resources.SimpleReloadableResourceManager.func_110541_a(SimpleReloadableResourceManager.java:112)
	at net.minecraft.client.Minecraft.func_110436_a(Minecraft.java:808)
	at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:247)
	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:467)
```


![image](https://user-images.githubusercontent.com/28797826/149645059-03842062-9dec-4b98-a9f8-d76eeec8cf56.png)
