### PR TITLE
Allow Gas Centrifuge to overclock

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/nuclear/MetaTileEntityGasCentrifuge.java
+++ b/src/main/java/gregicadditions/machines/multi/nuclear/MetaTileEntityGasCentrifuge.java
@@ -25,11 +25,7 @@ public class MetaTileEntityGasCentrifuge extends GARecipeMapMultiblockController
 
     public MetaTileEntityGasCentrifuge(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, GAS_CENTRIFUGE_RECIPES);
-        this.recipeMapWorkable = new GAMultiblockRecipeLogic(this) {
-            {
-                allowOverclocking = false;
-            }
-        };
+        this.recipeMapWorkable = new GAMultiblockRecipeLogic(this);
     }
 
     @Override


### PR DESCRIPTION
Now that bonus yield recipes have been removed, I believe this multiblock should be allowed to overclock. 