### PR TITLE
blacklist triniite from void miner mk1

### DIFF
--- a/src/main/java/gregicadditions/GAConfig.java
+++ b/src/main/java/gregicadditions/GAConfig.java
@@ -1419,7 +1419,7 @@ public class GAConfig {
             @Config.Comment("The name of the ores to blacklist for the MK1 Void Miner")
             @Config.RequiresMcRestart
             @Config.Name("MK1 Void Miner Blacklist")
-            public String[] oreBlacklist = new String[]{"trinium"};
+            public String[] oreBlacklist = new String[]{"trinium, triniite"};
 
             @Config.Comment("The name of the ores to blacklist for the MK2 Void Miner")
             @Config.RequiresMcRestart


### PR DESCRIPTION
Blacklists the production of Triniite from the Void Miner Mk1. This would previously cause a progression skip, as Trinium is intended to be gated behind the second miner.