### PR TITLE
fix multiblock recipe logic bugs

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/advance/MetaTileEntityAdvancedDistillationTower.java
+++ b/src/main/java/gregicadditions/machines/multi/advance/MetaTileEntityAdvancedDistillationTower.java
@@ -38,6 +38,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static gregicadditions.client.ClientHandler.BABBITT_ALLOY_CASING;
 import static gregicadditions.item.GAMetaBlocks.METAL_CASING_1;
@@ -140,6 +141,8 @@ public class MetaTileEntityAdvancedDistillationTower extends MultiRecipeMapMulti
             tierNeeded = Math.max(1, GAUtility.getTierByVoltage(matchingRecipe.getEUt()));
             maxItemsLimit *= currentTier - tierNeeded;
 
+            forceRecipeRecheck();
+
             if (mode == 0) { // Distillation tower = 2 parallel/oc, max 8
                 maxItemsLimit *= 2;
                 maxItemsLimit = Math.max(1, maxItemsLimit);
@@ -177,22 +180,23 @@ public class MetaTileEntityAdvancedDistillationTower extends MultiRecipeMapMulti
             List<FluidStack> outputF = new ArrayList<>();
             this.multiplyInputsAndOutputs(newRecipeInputs, newFluidInputs, outputI, outputF, matchingRecipe, minMultiplier);
 
+            RecipeBuilder<?> newRecipe = recipeMap.recipeBuilder();
+            copyChancedItemOutputs(newRecipe, matchingRecipe, minMultiplier);
+
             // determine if there is enough room in the output to fit all of this
-            boolean canFitOutputs = InventoryUtils.simulateItemStackMerge(outputI, this.getOutputInventory());
             // if there isn't, we can't process this recipe.
+            List<ItemStack> totalOutputs = newRecipe.getChancedOutputs().stream().map(Recipe.ChanceEntry::getItemStack).collect(Collectors.toList());
+            totalOutputs.addAll(outputI);
+            boolean canFitOutputs = InventoryUtils.simulateItemStackMerge(totalOutputs, this.getOutputInventory());
             if (!canFitOutputs)
-                return null;
+                return matchingRecipe;
 
-
-            RecipeBuilder<?> newRecipe = recipeMap.recipeBuilder()
-                    .inputsIngredients(newRecipeInputs)
+            newRecipe.inputsIngredients(newRecipeInputs)
                     .fluidInputs(newFluidInputs)
                     .outputs(outputI)
                     .fluidOutputs(outputF)
-                    .EUt((int) Math.max(1, EUt * this.getEUtPercentage() / 100))
+                    .EUt(Math.max(1, EUt * this.getEUtPercentage() / 100))
                     .duration((int) Math.max(3, duration * (this.getDurationPercentage() / 100.0)));
-
-            copyChancedItemOutputs(newRecipe, matchingRecipe, minMultiplier);
 
             return newRecipe.build().getResult();
         }


### PR DESCRIPTION
This PR fixes two significant bugs with multiblock logic.

Fixes a voiding bug which occurs with chanced outputs. If a recipe's parallel outputs can fit in the outputs, but not its parallel chanced outputs, the multiblock would previously run the recipe regardless, and void the entire recipe. This PR prevents this by checking if there is enough room to fit all the regular and chanced outputs combined together.

Fixes a bug where multiblocks will lock up if a parallel recipe cannot fit all of its item outputs. Previously, the only way to fix this was to make changes to the input inventory, which is not possible with automation other than laggy setups to unform and reform the structure. Buses were never checked again if the recipe could not fit. This is resolved by returning the non-parallel recipe if this were to happen, and forcing a recheck every time in order to attempt to re-acquire the parallel recipe if ever possible.

The PR also removes the string based logic for detecting empty output slots, and uses ItemStack.isEmpty() instead.