### PR TITLE
Fix Some Generators

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/GABoostableWorkableHandler.java
+++ b/src/main/java/gregicadditions/machines/multi/GABoostableWorkableHandler.java
@@ -39,9 +39,10 @@ public class GABoostableWorkableHandler extends GAFuelRecipeLogic {
 
     @Override
     protected int calculateFuelAmount(FuelRecipe currentRecipe) {
-
         FluidStack drainBooster = fluidTank.get().drain(booster, false);
+        System.out.println("Booster " + drainBooster);
         this.boosted = drainBooster != null && drainBooster.amount >= booster.amount;
+        System.out.println("Boosted " + boosted);
         return super.calculateFuelAmount(currentRecipe) * (boosted ? this.fuelMultiplier : 1);
     }
 

--- a/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorI.java
+++ b/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorI.java
@@ -30,6 +30,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
@@ -37,6 +38,7 @@ import java.util.Objects;
 import static gregicadditions.client.ClientHandler.NAQUADRIA_CASING;
 import static gregicadditions.item.GAMetaBlocks.METAL_CASING_2;
 import static gregtech.api.unification.material.Materials.Helium;
+import static gregtech.api.unification.material.Materials.Radon;
 
 public class MetaTileEntityHyperReactorI extends GAFueledMultiblockController {
 
@@ -44,19 +46,24 @@ public class MetaTileEntityHyperReactorI extends GAFueledMultiblockController {
             MultiblockAbility.OUTPUT_ENERGY, MultiblockAbility.IMPORT_FLUIDS, GregicAdditionsCapabilities.MAINTENANCE_HATCH
     };
 
+    private long maxVoltage;
+    private FluidStack booster;
+
     public MetaTileEntityHyperReactorI(ResourceLocation metaTileEntityId, long maxVoltage) {
         super(metaTileEntityId, GARecipeMaps.HYPER_REACTOR_FUELS, maxVoltage);
         this.maxVoltage = maxVoltage;
+        this.booster = getBooster();
+    }
+
+    @Nonnull
+    private FluidStack getBooster() {
         Fluid temp = FluidRegistry.getFluid(GAConfig.multis.hyperReactors.boosterFluid[0]);
         if (temp == null) {
             temp = Helium.getMaterialPlasma();
             GALog.logger.warn("Incorrect fluid given to hyper reactor: " + GAConfig.multis.hyperReactors.boosterFluid[0]);
         }
-        booster = new FluidStack(temp, GAConfig.multis.hyperReactors.boosterFluidAmounts[0]);
+        return new FluidStack(Objects.requireNonNull(temp), GAConfig.multis.hyperReactors.boosterFluidAmounts[0]);
     }
-
-    long maxVoltage;
-    FluidStack booster;
 
     @Override
     public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
@@ -68,7 +75,7 @@ public class MetaTileEntityHyperReactorI extends GAFueledMultiblockController {
         int fuelMultiplier = GAConfig.multis.hyperReactors.boostedFuelAmount[0];
         int euMultiplier = GAConfig.multis.hyperReactors.boostedEuAmount[0];
         return new GABoostableWorkableHandler(this, recipeMap, () -> energyContainer, () -> importFluidHandler,
-                maxVoltage, booster, fuelMultiplier, euMultiplier);
+                maxVoltage, getBooster(), fuelMultiplier, euMultiplier);
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorII.java
+++ b/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorII.java
@@ -7,7 +7,6 @@ import gregicadditions.item.GAMetaBlocks;
 import gregicadditions.item.GAReactorCasing;
 import gregicadditions.machines.multi.GABoostableWorkableHandler;
 import gregicadditions.machines.multi.GAFueledMultiblockController;
-import gregicadditions.recipes.impl.BoostableWorkableHandler;
 import gregicadditions.recipes.GARecipeMaps;
 import gregicadditions.utils.GALog;
 import gregtech.api.capability.impl.FuelRecipeLogic;
@@ -19,7 +18,6 @@ import gregtech.api.multiblock.BlockPattern;
 import gregtech.api.multiblock.FactoryBlockPattern;
 import gregtech.api.render.ICubeRenderer;
 import gregtech.common.blocks.MetaBlocks;
-import gregtech.common.metatileentities.multi.electric.generator.FueledMultiblockController;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -30,6 +28,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
@@ -43,20 +42,24 @@ public class MetaTileEntityHyperReactorII extends GAFueledMultiblockController {
             MultiblockAbility.OUTPUT_ENERGY, MultiblockAbility.IMPORT_FLUIDS, GregicAdditionsCapabilities.MAINTENANCE_HATCH
     };
 
+    private long maxVoltage;
+    private FluidStack booster;
+
     public MetaTileEntityHyperReactorII(ResourceLocation metaTileEntityId, long maxVoltage) {
         super(metaTileEntityId, GARecipeMaps.HYPER_REACTOR_FUELS, maxVoltage);
         this.maxVoltage = maxVoltage;
+        this.booster = getBooster();
+    }
+
+    @Nonnull
+    private FluidStack getBooster() {
         Fluid temp = FluidRegistry.getFluid(GAConfig.multis.hyperReactors.boosterFluid[1]);
         if (temp == null) {
             temp = Radon.getMaterialPlasma();
             GALog.logger.warn("Incorrect fluid given to hyper reactor: " + GAConfig.multis.hyperReactors.boosterFluid[1]);
         }
-        booster = new FluidStack(temp, GAConfig.multis.hyperReactors.boosterFluidAmounts[1]);
+        return new FluidStack(Objects.requireNonNull(temp), GAConfig.multis.hyperReactors.boosterFluidAmounts[1]);
     }
-
-    long maxVoltage;
-    FluidStack booster;
-
 
     @Override
     public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
@@ -68,7 +71,7 @@ public class MetaTileEntityHyperReactorII extends GAFueledMultiblockController {
         int fuelMultiplier = GAConfig.multis.hyperReactors.boostedFuelAmount[1];
         int euMultiplier = GAConfig.multis.hyperReactors.boostedEuAmount[1];
         return new GABoostableWorkableHandler(this, recipeMap, () -> energyContainer, () -> importFluidHandler,
-                maxVoltage, booster, fuelMultiplier, euMultiplier);
+                maxVoltage, getBooster(), fuelMultiplier, euMultiplier);
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorII.java
+++ b/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorII.java
@@ -6,6 +6,7 @@ import gregicadditions.client.ClientHandler;
 import gregicadditions.item.GAMetaBlocks;
 import gregicadditions.item.GAReactorCasing;
 import gregicadditions.machines.multi.GABoostableWorkableHandler;
+import gregicadditions.machines.multi.GAFueledMultiblockController;
 import gregicadditions.recipes.impl.BoostableWorkableHandler;
 import gregicadditions.recipes.GARecipeMaps;
 import gregicadditions.utils.GALog;
@@ -36,7 +37,7 @@ import java.util.Objects;
 import static gregtech.api.unification.material.Materials.Naquadria;
 import static gregtech.api.unification.material.Materials.Radon;
 
-public class MetaTileEntityHyperReactorII extends FueledMultiblockController {
+public class MetaTileEntityHyperReactorII extends GAFueledMultiblockController {
 
     public static final MultiblockAbility<?>[] ALLOWED_ABILITIES = {
             MultiblockAbility.OUTPUT_ENERGY, MultiblockAbility.IMPORT_FLUIDS, GregicAdditionsCapabilities.MAINTENANCE_HATCH

--- a/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorIII.java
+++ b/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorIII.java
@@ -7,6 +7,7 @@ import gregicadditions.item.GAMetaBlocks;
 import gregicadditions.item.GAReactorCasing;
 import gregicadditions.item.GATransparentCasing;
 import gregicadditions.machines.multi.GABoostableWorkableHandler;
+import gregicadditions.machines.multi.GAFueledMultiblockController;
 import gregicadditions.recipes.impl.BoostableWorkableHandler;
 import gregicadditions.recipes.GARecipeMaps;
 import gregicadditions.utils.GALog;
@@ -36,7 +37,7 @@ import java.util.Objects;
 
 import static gregtech.api.unification.material.Materials.*;
 
-public class MetaTileEntityHyperReactorIII extends FueledMultiblockController {
+public class MetaTileEntityHyperReactorIII extends GAFueledMultiblockController {
 
 
     public MetaTileEntityHyperReactorIII(ResourceLocation metaTileEntityId, long maxVoltage) {

--- a/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorIII.java
+++ b/src/main/java/gregicadditions/machines/multi/advance/hyper/MetaTileEntityHyperReactorIII.java
@@ -31,6 +31,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
@@ -39,20 +40,25 @@ import static gregtech.api.unification.material.Materials.*;
 
 public class MetaTileEntityHyperReactorIII extends GAFueledMultiblockController {
 
+    private long maxVoltage;
+    private FluidStack booster;
 
     public MetaTileEntityHyperReactorIII(ResourceLocation metaTileEntityId, long maxVoltage) {
         super(metaTileEntityId, GARecipeMaps.HYPER_REACTOR_FUELS, maxVoltage);
         this.maxVoltage = maxVoltage;
+        if (getWorld() != null && !getWorld().isRemote)
+            this.booster = getBooster();
+    }
+
+    @Nonnull
+    private FluidStack getBooster() {
         Fluid temp = FluidRegistry.getFluid(GAConfig.multis.hyperReactors.boosterFluid[2]);
         if (temp == null) {
             temp = Helium.getMaterialPlasma();
             GALog.logger.warn("Incorrect fluid given to hyper reactor: " + GAConfig.multis.hyperReactors.boosterFluid[2]);
         }
-        booster = new FluidStack(temp, GAConfig.multis.hyperReactors.boosterFluidAmounts[2]);
+        return new FluidStack(Objects.requireNonNull(temp), GAConfig.multis.hyperReactors.boosterFluidAmounts[2]);
     }
-
-    long maxVoltage;
-    FluidStack booster;
 
     @Override
     public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
@@ -64,7 +70,7 @@ public class MetaTileEntityHyperReactorIII extends GAFueledMultiblockController 
         int fuelMultiplier = GAConfig.multis.hyperReactors.boostedFuelAmount[2];
         int euMultiplier = GAConfig.multis.hyperReactors.boostedEuAmount[2];
         return new GABoostableWorkableHandler(this, recipeMap, () -> energyContainer, () -> importFluidHandler,
-                maxVoltage, booster, fuelMultiplier, euMultiplier);
+                maxVoltage, getBooster(), fuelMultiplier, euMultiplier);
     }
 
     @Override


### PR DESCRIPTION
Fixes Hyper Reactors 2 and 3 extending the wrong class. This meant that they did not require maintenance hatches, and did not boost their output.