### PR TITLE
changes to hyper 3 and large naq reactor recipes

### DIFF
--- a/src/main/java/gregicadditions/recipes/categories/machines/MultiblockCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/categories/machines/MultiblockCraftingRecipes.java
@@ -184,7 +184,7 @@ public class MultiblockCraftingRecipes {
         // Naquadah Reactor
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(1000).EUt(90000)
                 .fluidInputs(SolderingAlloy.getFluid(L * 20))
-                .fluidInputs(Protactinium233.getMaterial().getFluid(L * 2))
+                .fluidInputs(Einsteinium253.getMaterial().getFluid(L * 2))
                 .input(plate, Tritanium, 8)
                 .input(foil, EnrichedNaquadahAlloy, 24)
                 .input(gear, Duranium, 16)

--- a/src/main/java/gregicadditions/recipes/chain/NaquadahChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/NaquadahChain.java
@@ -723,7 +723,7 @@ public class NaquadahChain {
                 .fluidInputs(HeavyENaquadahFuel.getFluid(400))
                 .fluidInputs(NaquadriaSolution.getFluid(300))
                 .input(dust, Adamantium)
-                .fluidInputs(Californium256.getMaterial().getFluid(144))
+                .fluidInputs(Fermium258.getMaterial().getFluid(144))
                 .fluidOutputs(HyperFuelIII.getFluid(2000))
                 .EUt(30720)
                 .duration(200)


### PR DESCRIPTION
Changes the isotope used in the large naq reactor recipe to one later in the fission chain. This more closely follows the singleblock naq reactor isotope tearing.

Also changes the isotope used in hyper fuel 3. The new isotope has a higher yield, but requires more infrastructure to reach.